### PR TITLE
Correct typo in `glGetProgramResourceName` loader

### DIFF
--- a/src/zopengl.zig
+++ b/src/zopengl.zig
@@ -642,7 +642,7 @@ pub fn loadCoreProfile(loader: LoaderFn, major: u32, minor: u32) !void {
         try load("glMultiDrawElementsIndirect", .{&bindings.multiDrawElementsIndirect});
         try load("glGetProgramInterfaceiv", .{&bindings.getProgramInterfaceiv});
         try load("glGetProgramResourceIndex", .{&bindings.getProgramResourceIndex});
-        try load("glGetPrtgramResourceName", .{&bindings.getProgramResourceName});
+        try load("glGetProgramResourceName", .{&bindings.getProgramResourceName});
         try load("glGetProgramResourceiv", .{&bindings.getProgramResourceiv});
         try load("glGetProgramResourceLocation", .{&bindings.getProgramResourceLocation});
         try load("glGetProgramResourceLocationIndex", .{&bindings.getProgramResourceLocationIndex});


### PR DESCRIPTION
Loader for `glGetProgramResourceName` is incorrectly spelt as `glGetPrtgramResourceName`.

Fairly minor issue, but it currently causes a crash whenever the core profile is loaded with version >=4.3.