### PR TITLE
Increase OpenGL version number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 OpenGL loader, bindings and optional wrapper for Zig.
 
 Supports:
-  * OpenGL Core Profile up to version 4.2
+  * OpenGL Core Profile up to version 4.3
   * OpenGL ES up to version 2.0
 
 ## Getting started


### PR DESCRIPTION
This small PR increases the version number of OpenGL in the README since #4 was merged.
This would also have to be fixed in the zig-gamedev repo (the one that's displayed on https://github.com/zig-gamedev)